### PR TITLE
Fix LAB utilities dimension and device handling

### DIFF
--- a/IQA_pytorch/utils.py
+++ b/IQA_pytorch/utils.py
@@ -47,87 +47,104 @@ def preprocess_lab(lab):
 		return [L_chan / 50.0 - 1.0, a_chan / 110.0, b_chan / 110.0]
 
 def deprocess_lab(L_chan, a_chan, b_chan):
-		#TODO This is axis=3 instead of axis=2 when deprocessing batch of images 
-			   # ( we process individual images but deprocess batches)
-		#return tf.stack([(L_chan + 1) / 2 * 100, a_chan * 110, b_chan * 110], axis=3)
-		return torch.stack([(L_chan + 1) / 2.0 * 100.0, a_chan * 110.0, b_chan * 110.0], dim=2)
+    # Stack the L, a and b channels back together. When processing batches of
+    # images the channel dimension is the last one, so we stack along dim=3 to
+    # obtain an output shaped (N, H, W, 3).
+    return torch.stack(
+        [(L_chan + 1) / 2.0 * 100.0, a_chan * 110.0, b_chan * 110.0], dim=3
+    )
 
 def rgb_to_lab(srgb):
-    srgb = srgb/255
+    device = srgb.device
+    srgb = srgb / 255
     srgb_pixels = torch.reshape(srgb, [-1, 3])
     linear_mask = (srgb_pixels <= 0.04045).type(torch.FloatTensor).to(device)
     exponential_mask = (srgb_pixels > 0.04045).type(torch.FloatTensor).to(device)
-    rgb_pixels = (srgb_pixels / 12.92 * linear_mask) + (((srgb_pixels + 0.055) / 1.055) ** 2.4) * exponential_mask
-	
+    rgb_pixels = (srgb_pixels / 12.92 * linear_mask) + (
+        ((srgb_pixels + 0.055) / 1.055) ** 2.4
+    ) * exponential_mask
+
     rgb_to_xyz = torch.tensor([
-				#    X        Y          Z
-				[0.412453, 0.212671, 0.019334], # R
-				[0.357580, 0.715160, 0.119193], # G
-				[0.180423, 0.072169, 0.950227], # B
-			]).type(torch.FloatTensor).to(device)
-	
+        #    X        Y          Z
+        [0.412453, 0.212671, 0.019334],  # R
+        [0.357580, 0.715160, 0.119193],  # G
+        [0.180423, 0.072169, 0.950227],  # B
+    ]).type(torch.FloatTensor).to(device)
+
     xyz_pixels = torch.mm(rgb_pixels, rgb_to_xyz)
-	
 
     # XYZ to Lab
-    xyz_normalized_pixels = torch.mul(xyz_pixels, torch.tensor([1/0.950456, 1.0, 1/1.088754]).type(torch.FloatTensor).to(device))
+    xyz_normalized_pixels = torch.mul(
+        xyz_pixels,
+        torch.tensor([1 / 0.950456, 1.0, 1 / 1.088754]).type(torch.FloatTensor).to(device),
+    )
 
-    epsilon = 6.0/29.0
+    epsilon = 6.0 / 29.0
     linear_mask = (xyz_normalized_pixels <= (epsilon**3)).type(torch.FloatTensor).to(device)
     exponential_mask = (xyz_normalized_pixels > (epsilon**3)).type(torch.FloatTensor).to(device)
-    fxfyfz_pixels = (xyz_normalized_pixels / (3 * epsilon**2) + 4.0/29.0) * linear_mask + ((xyz_normalized_pixels+0.000001) ** (1.0/3.0)) * exponential_mask
+    fxfyfz_pixels = (
+        (xyz_normalized_pixels / (3 * epsilon**2) + 4.0 / 29.0) * linear_mask
+        + ((xyz_normalized_pixels + 1e-6) ** (1.0 / 3.0)) * exponential_mask
+    )
     # convert to lab
     fxfyfz_to_lab = torch.tensor([
         #  l       a       b
-        [  0.0,  500.0,    0.0], # fx
-        [116.0, -500.0,  200.0], # fy
-        [  0.0,    0.0, -200.0], # fz
+        [0.0, 500.0, 0.0],  # fx
+        [116.0, -500.0, 200.0],  # fy
+        [0.0, 0.0, -200.0],  # fz
     ]).type(torch.FloatTensor).to(device)
     lab_pixels = torch.mm(fxfyfz_pixels, fxfyfz_to_lab) + torch.tensor([-16.0, 0.0, 0.0]).type(torch.FloatTensor).to(device)
-    #return tf.reshape(lab_pixels, tf.shape(srgb))
     return torch.reshape(lab_pixels, srgb.shape)
 
 def lab_to_rgb(lab):
-		lab_pixels = torch.reshape(lab, [-1, 3])
-		# convert to fxfyfz
-		lab_to_fxfyfz = torch.tensor([
-			#   fx      fy        fz
-			[1/116.0, 1/116.0,  1/116.0], # l
-			[1/500.0,     0.0,      0.0], # a
-			[    0.0,     0.0, -1/200.0], # b
-		]).type(torch.FloatTensor).to(device)
-		fxfyfz_pixels = torch.mm(lab_pixels + torch.tensor([16.0, 0.0, 0.0]).type(torch.FloatTensor).to(device), lab_to_fxfyfz)
+    device = lab.device
+    lab_pixels = torch.reshape(lab, [-1, 3])
+    # convert to fxfyfz
+    lab_to_fxfyfz = torch.tensor([
+        #   fx      fy        fz
+        [1 / 116.0, 1 / 116.0, 1 / 116.0],  # l
+        [1 / 500.0, 0.0, 0.0],  # a
+        [0.0, 0.0, -1 / 200.0],  # b
+    ]).type(torch.FloatTensor).to(device)
+    fxfyfz_pixels = torch.mm(
+        lab_pixels + torch.tensor([16.0, 0.0, 0.0]).type(torch.FloatTensor).to(device),
+        lab_to_fxfyfz,
+    )
 
-		# convert to xyz
-		epsilon = 6.0/29.0
-		linear_mask = (fxfyfz_pixels <= epsilon).type(torch.FloatTensor).to(device)
-		exponential_mask = (fxfyfz_pixels > epsilon).type(torch.FloatTensor).to(device)
+    # convert to xyz
+    epsilon = 6.0 / 29.0
+    linear_mask = (fxfyfz_pixels <= epsilon).type(torch.FloatTensor).to(device)
+    exponential_mask = (fxfyfz_pixels > epsilon).type(torch.FloatTensor).to(device)
 
+    xyz_pixels = (
+        3 * epsilon**2 * (fxfyfz_pixels - 4 / 29.0)
+    ) * linear_mask + ((fxfyfz_pixels + 1e-6) ** 3) * exponential_mask
 
-		xyz_pixels = (3 * epsilon**2 * (fxfyfz_pixels - 4/29.0)) * linear_mask + ((fxfyfz_pixels+0.000001) ** 3) * exponential_mask
+    # denormalize for D65 white point
+    xyz_pixels = torch.mul(
+        xyz_pixels,
+        torch.tensor([0.950456, 1.0, 1.088754]).type(torch.FloatTensor).to(device),
+    )
 
-		# denormalize for D65 white point
-		xyz_pixels = torch.mul(xyz_pixels, torch.tensor([0.950456, 1.0, 1.088754]).type(torch.FloatTensor).to(device))
+    xyz_to_rgb = torch.tensor([
+        #     r           g          b
+        [3.2404542, -0.9692660, 0.0556434],  # x
+        [-1.5371385, 1.8760108, -0.2040259],  # y
+        [-0.4985314, 0.0415560, 1.0572252],  # z
+    ]).type(torch.FloatTensor).to(device)
 
+    rgb_pixels = torch.mm(xyz_pixels, xyz_to_rgb)
+    # avoid a slightly negative number messing up the conversion
+    rgb_pixels[rgb_pixels > 1] = 1
+    rgb_pixels[rgb_pixels < 0] = 0
 
-		xyz_to_rgb = torch.tensor([
-			#     r           g          b
-			[ 3.2404542, -0.9692660,  0.0556434], # x
-			[-1.5371385,  1.8760108, -0.2040259], # y
-			[-0.4985314,  0.0415560,  1.0572252], # z
-		]).type(torch.FloatTensor).to(device)
+    linear_mask = (rgb_pixels <= 0.0031308).type(torch.FloatTensor).to(device)
+    exponential_mask = (rgb_pixels > 0.0031308).type(torch.FloatTensor).to(device)
+    srgb_pixels = (rgb_pixels * 12.92 * linear_mask) + (
+        ((rgb_pixels + 1e-6) ** (1 / 2.4) * 1.055) - 0.055
+    ) * exponential_mask
 
-		rgb_pixels =  torch.mm(xyz_pixels, xyz_to_rgb)
-		# avoid a slightly negative number messing up the conversion
-		#clip
-		rgb_pixels[rgb_pixels > 1] = 1
-		rgb_pixels[rgb_pixels < 0] = 0
-
-		linear_mask = (rgb_pixels <= 0.0031308).type(torch.FloatTensor).to(device)
-		exponential_mask = (rgb_pixels > 0.0031308).type(torch.FloatTensor).to(device)
-		srgb_pixels = (rgb_pixels * 12.92 * linear_mask) + (((rgb_pixels+0.000001) ** (1/2.4) * 1.055) - 0.055) * exponential_mask
-	
-		return torch.reshape(srgb_pixels, lab.shape)
+    return torch.reshape(srgb_pixels, lab.shape)
 
 def spatial_normalize(x):
     min_v = torch.min(x.view(x.shape[0],1,-1),dim=2)[0]


### PR DESCRIPTION
## Summary
- fix `deprocess_lab` to stack LAB channels on the correct dimension for batched tensors
- ensure LAB<->RGB conversions run on the input tensor's device instead of an undefined global

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python - <<'PY'
import torch
from IQA_pytorch.utils import rgb_to_lab, lab_to_rgb, deprocess_lab
srgb = torch.rand(2,4,4,3)
lab = rgb_to_lab(srgb)
srgb_back = lab_to_rgb(lab)
print('lab shape', lab.shape)
print('srgb_back shape', srgb_back.shape)
L, a, b = lab[...,0], lab[...,1], lab[...,2]
lab_re = deprocess_lab(L,a,b)
print('deprocess_lab shape', lab_re.shape)
PY`

------
https://chatgpt.com/codex/tasks/task_e_68aec050079083228751382518b54453